### PR TITLE
Feature/group repo infra

### DIFF
--- a/infrastructure/mongo/repository/group.go
+++ b/infrastructure/mongo/repository/group.go
@@ -1,0 +1,1 @@
+package repository

--- a/infrastructure/mongo/repository/group.go
+++ b/infrastructure/mongo/repository/group.go
@@ -1,1 +1,109 @@
 package repository
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"chikokulympic-api/domain/entity"
+	repo "chikokulympic-api/domain/repository"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+type GroupRepo struct {
+	collection *mongo.Collection
+}
+
+func NewGroupRepo(db *mongo.Database) repo.GroupRepository {
+	return &GroupRepo{
+		collection: db.Collection("groups"),
+	}
+}
+
+func (gr *GroupRepo) FindGroupByGroupName(groupName *entity.GroupName) (*entity.Group, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	var group entity.Group
+	filter := bson.M{"name": groupName}
+	err := gr.collection.FindOne(ctx, filter).Decode(&group)
+	if err != nil {
+		if err == mongo.ErrNoDocuments {
+			return nil, fmt.Errorf("group not found with name: %s", *groupName)
+		}
+		return nil, fmt.Errorf("error finding group by name: %w", err)
+	}
+
+	return &group, nil
+}
+
+func (gr *GroupRepo) FindGroupByUserID(userID entity.UserID) (*entity.Group, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	var group entity.Group
+	filter := bson.M{
+		"$or": []bson.M{
+			{"manager_id": userID},
+			{"members": bson.M{"$in": []entity.UserID{userID}}},
+		},
+	}
+
+	err := gr.collection.FindOne(ctx, filter).Decode(&group)
+	if err != nil {
+		if err == mongo.ErrNoDocuments {
+			return nil, fmt.Errorf("no group found for user ID: %s", userID)
+		}
+		return nil, fmt.Errorf("error finding group by user ID: %w", err)
+	}
+
+	return &group, nil
+}
+
+func (gr *GroupRepo) CreateGroup(group *entity.Group) (*entity.Group, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	existingGroup, err := gr.FindGroupByGroupName(&group.GroupName)
+	if err == nil && existingGroup != nil {
+		return nil, fmt.Errorf("group with name %s already exists", group.GroupName)
+	}
+
+	_, err = gr.collection.InsertOne(ctx, group)
+	if err != nil {
+		return nil, fmt.Errorf("error creating group: %w", err)
+	}
+
+	return group, nil
+}
+
+func (gr *GroupRepo) UpdateGroup(group *entity.Group) (*entity.Group, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	filter := bson.M{"group_id": group.GroupID}
+	update := bson.M{"$set": group}
+
+	_, err := gr.collection.UpdateOne(ctx, filter, update)
+	if err != nil {
+		return nil, fmt.Errorf("error updating group: %w", err)
+	}
+
+	return group, nil
+}
+
+func (gr *GroupRepo) DeleteGroup(group *entity.Group) (*entity.Group, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	filter := bson.M{"group_id": group.GroupID}
+
+	_, err := gr.collection.DeleteOne(ctx, filter)
+	if err != nil {
+		return nil, fmt.Errorf("error deleting group: %w", err)
+	}
+
+	return group, nil
+}

--- a/infrastructure/mongo/repository/group_test.go
+++ b/infrastructure/mongo/repository/group_test.go
@@ -1,0 +1,230 @@
+package repository_test
+
+import (
+	"context"
+	"testing"
+
+	"chikokulympic-api/domain/entity"
+	"chikokulympic-api/infrastructure/mongo/repository"
+	"chikokulympic-api/infrastructure/mongo/repository/testUtils"
+
+	"github.com/stretchr/testify/assert"
+	"go.mongodb.org/mongo-driver/bson"
+)
+
+func TestFindGroupByGroupName(t *testing.T) {
+	db, cleanup := testUtils.SetupTestDB(t)
+	defer cleanup()
+
+	testGroup := &entity.Group{
+		GroupID:          "test-group-id",
+		GroupName:        "TestGroup",
+		GroupPassword:    "password123",
+		GroupManagerID:   "manager-user-id",
+		GroupDescription: "Test group description",
+		GroupMembers:     []entity.UserID{"member1-id", "member2-id"},
+		GroupEvents:      []entity.EventID{"event1-id", "event2-id"},
+	}
+
+	_, err := db.Collection("groups").InsertOne(context.Background(), testGroup)
+	assert.NoError(t, err)
+
+	repo := repository.NewGroupRepo(db)
+
+	foundGroup, err := repo.FindGroupByGroupName(&testGroup.GroupName)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, foundGroup)
+	assert.Equal(t, testGroup.GroupID, foundGroup.GroupID)
+	assert.Equal(t, testGroup.GroupName, foundGroup.GroupName)
+	assert.Equal(t, testGroup.GroupManagerID, foundGroup.GroupManagerID)
+}
+
+func TestFindGroupByUserID(t *testing.T) {
+	db, cleanup := testUtils.SetupTestDB(t)
+	defer cleanup()
+
+	managerID := entity.UserID("manager-user-id")
+	memberID := entity.UserID("member1-id")
+
+	testGroup := &entity.Group{
+		GroupID:          "test-group-id",
+		GroupName:        "TestGroup",
+		GroupPassword:    "password123",
+		GroupManagerID:   managerID,
+		GroupDescription: "Test group description",
+		GroupMembers:     []entity.UserID{memberID, "member2-id"},
+		GroupEvents:      []entity.EventID{"event1-id", "event2-id"},
+	}
+
+	_, err := db.Collection("groups").InsertOne(context.Background(), testGroup)
+	assert.NoError(t, err)
+
+	repo := repository.NewGroupRepo(db)
+
+	// マネージャーIDでの検索テスト
+	foundGroup, err := repo.FindGroupByUserID(managerID)
+	assert.NoError(t, err)
+	assert.NotNil(t, foundGroup)
+	assert.Equal(t, testGroup.GroupID, foundGroup.GroupID)
+
+	// メンバーIDでの検索テスト
+	foundGroup, err = repo.FindGroupByUserID(memberID)
+	assert.NoError(t, err)
+	assert.NotNil(t, foundGroup)
+	assert.Equal(t, testGroup.GroupID, foundGroup.GroupID)
+}
+
+func TestCreateGroup(t *testing.T) {
+	db, cleanup := testUtils.SetupTestDB(t)
+	defer cleanup()
+
+	repo := repository.NewGroupRepo(db)
+
+	testGroup := &entity.Group{
+		GroupID:          "new-group-id",
+		GroupName:        "NewGroup",
+		GroupPassword:    "newpassword",
+		GroupManagerID:   "new-manager-id",
+		GroupDescription: "New group description",
+		GroupMembers:     []entity.UserID{"new-member1-id", "new-member2-id"},
+		GroupEvents:      []entity.EventID{"new-event1-id", "new-event2-id"},
+	}
+
+	createdGroup, err := repo.CreateGroup(testGroup)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, createdGroup)
+	assert.Equal(t, testGroup.GroupID, createdGroup.GroupID)
+	assert.Equal(t, testGroup.GroupName, createdGroup.GroupName)
+
+	var savedGroup entity.Group
+	err = db.Collection("groups").FindOne(context.Background(), bson.M{"group_id": testGroup.GroupID}).Decode(&savedGroup)
+	assert.NoError(t, err)
+	assert.Equal(t, testGroup.GroupName, savedGroup.GroupName)
+	assert.Equal(t, testGroup.GroupDescription, savedGroup.GroupDescription)
+}
+
+func TestCreateGroupDuplicate(t *testing.T) {
+	db, cleanup := testUtils.SetupTestDB(t)
+	defer cleanup()
+
+	repo := repository.NewGroupRepo(db)
+
+	testGroup := &entity.Group{
+		GroupID:          "existing-group-id",
+		GroupName:        "ExistingGroup",
+		GroupPassword:    "password123",
+		GroupManagerID:   "manager-id",
+		GroupDescription: "Existing group description",
+		GroupMembers:     []entity.UserID{"member1-id", "member2-id"},
+		GroupEvents:      []entity.EventID{"event1-id", "event2-id"},
+	}
+
+	// 最初のグループ作成
+	_, err := repo.CreateGroup(testGroup)
+	assert.NoError(t, err)
+
+	// 同じ名前で再度作成を試みる
+	duplicateGroup := &entity.Group{
+		GroupID:          "another-group-id",
+		GroupName:        testGroup.GroupName, // 同じ名前
+		GroupPassword:    "anotherpassword",
+		GroupManagerID:   "another-manager-id",
+		GroupDescription: "Another group description",
+	}
+
+	_, err = repo.CreateGroup(duplicateGroup)
+	assert.Error(t, err) // エラーが返されることを期待
+}
+
+func TestUpdateGroup(t *testing.T) {
+	db, cleanup := testUtils.SetupTestDB(t)
+	defer cleanup()
+
+	testGroup := &entity.Group{
+		GroupID:          "update-group-id",
+		GroupName:        "UpdateGroup",
+		GroupPassword:    "updatepassword",
+		GroupManagerID:   "update-manager-id",
+		GroupDescription: "Update group description",
+		GroupMembers:     []entity.UserID{"update-member1-id", "update-member2-id"},
+		GroupEvents:      []entity.EventID{"update-event1-id", "update-event2-id"},
+	}
+
+	_, err := db.Collection("groups").InsertOne(context.Background(), testGroup)
+	assert.NoError(t, err)
+
+	repo := repository.NewGroupRepo(db)
+
+	// グループ情報の更新
+	updatedDescription := entity.GroupDescription("Updated group description")
+	updatedMembers := entity.GroupMembers{"update-member1-id", "update-member2-id", "update-member3-id"}
+
+	testGroup.GroupDescription = updatedDescription
+	testGroup.GroupMembers = updatedMembers
+
+	updatedGroup, err := repo.UpdateGroup(testGroup)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, updatedGroup)
+	assert.Equal(t, updatedDescription, updatedGroup.GroupDescription)
+	assert.Equal(t, len(updatedMembers), len(updatedGroup.GroupMembers))
+
+	// DBから直接取得して確認
+	var savedGroup entity.Group
+	err = db.Collection("groups").FindOne(context.Background(), bson.M{"group_id": testGroup.GroupID}).Decode(&savedGroup)
+	assert.NoError(t, err)
+	assert.Equal(t, updatedDescription, savedGroup.GroupDescription)
+	assert.Equal(t, len(updatedMembers), len(savedGroup.GroupMembers))
+}
+
+func TestDeleteGroup(t *testing.T) {
+	db, cleanup := testUtils.SetupTestDB(t)
+	defer cleanup()
+
+	testGroup := &entity.Group{
+		GroupID:          "delete-group-id",
+		GroupName:        "DeleteGroup",
+		GroupPassword:    "deletepassword",
+		GroupManagerID:   "delete-manager-id",
+		GroupDescription: "Delete group description",
+		GroupMembers:     []entity.UserID{"delete-member1-id", "delete-member2-id"},
+		GroupEvents:      []entity.EventID{"delete-event1-id", "delete-event2-id"},
+	}
+
+	_, err := db.Collection("groups").InsertOne(context.Background(), testGroup)
+	assert.NoError(t, err)
+
+	repo := repository.NewGroupRepo(db)
+
+	deletedGroup, err := repo.DeleteGroup(testGroup)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, deletedGroup)
+	assert.Equal(t, testGroup.GroupID, deletedGroup.GroupID)
+
+	var count int64
+	count, err = db.Collection("groups").CountDocuments(context.Background(), bson.M{"group_id": testGroup.GroupID})
+	assert.NoError(t, err)
+	assert.Equal(t, int64(0), count)
+}
+
+func TestFindGroupNotFound(t *testing.T) {
+	db, cleanup := testUtils.SetupTestDB(t)
+	defer cleanup()
+
+	repo := repository.NewGroupRepo(db)
+
+	nonExistentName := entity.GroupName("NonExistentGroup")
+	group, err := repo.FindGroupByGroupName(&nonExistentName)
+
+	assert.Error(t, err)
+	assert.Nil(t, group)
+
+	nonExistentUserID := entity.UserID("non-existent-user-id")
+	group, err = repo.FindGroupByUserID(nonExistentUserID)
+
+	assert.Error(t, err)
+	assert.Nil(t, group)
+}

--- a/infrastructure/mongo/repository/testUtils/testUtils.go
+++ b/infrastructure/mongo/repository/testUtils/testUtils.go
@@ -2,6 +2,8 @@ package testUtils
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"testing"
 
 	mongoDB "chikokulympic-api/infrastructure/mongo"
@@ -9,9 +11,34 @@ import (
 	"go.mongodb.org/mongo-driver/mongo"
 )
 
-// SetupTestDB はテスト用のMongoDBデータベースを準備し、クリーンアップ関数を返します
+func findProjectRoot() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir, nil
+		}
+
+		parentDir := filepath.Dir(dir)
+		if parentDir == dir {
+			return "", os.ErrNotExist
+		}
+		dir = parentDir
+	}
+}
+
 func SetupTestDB(t *testing.T) (*mongo.Database, func()) {
-	db, client, err := mongoDB.GetMongoDBConnectionWithEnvFile(".env.local")
+	rootDir, err := findProjectRoot()
+	if err != nil {
+		t.Fatalf("Failed to find project root: %v", err)
+	}
+
+	envPath := filepath.Join(rootDir, ".env.local")
+
+	db, client, err := mongoDB.GetMongoDBConnectionWithEnvFile(envPath)
 	if err != nil {
 		t.Fatalf("Failed to connect to MongoDB: %v", err)
 	}

--- a/infrastructure/mongo/repository/testUtils/testUtils.go
+++ b/infrastructure/mongo/repository/testUtils/testUtils.go
@@ -1,0 +1,32 @@
+package testUtils
+
+import (
+	"context"
+	"testing"
+
+	mongoDB "chikokulympic-api/infrastructure/mongo"
+
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+// SetupTestDB はテスト用のMongoDBデータベースを準備し、クリーンアップ関数を返します
+func SetupTestDB(t *testing.T) (*mongo.Database, func()) {
+	db, client, err := mongoDB.GetMongoDBConnectionWithEnvFile(".env.local")
+	if err != nil {
+		t.Fatalf("Failed to connect to MongoDB: %v", err)
+	}
+
+	cleanup := func() {
+		err := db.Drop(context.Background())
+		if err != nil {
+			t.Logf("Warning: Failed to drop test database: %v", err)
+		}
+
+		err = mongoDB.DisconnectMongoDB(client)
+		if err != nil {
+			t.Logf("Warning: Failed to disconnect from MongoDB: %v", err)
+		}
+	}
+
+	return db, cleanup
+}

--- a/infrastructure/mongo/repository/user.go
+++ b/infrastructure/mongo/repository/user.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 
 	"chikokulympic-api/domain/entity"
-	"chikokulympic-api/domain/repository"
+	repo "chikokulympic-api/domain/repository"
 
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
@@ -16,7 +16,7 @@ type userRepository struct {
 	userCollection *mongo.Collection
 }
 
-func NewUserRepository(db *mongo.Database) repository.UserRepository {
+func NewUserRepository(db *mongo.Database) repo.UserRepository {
 	return &userRepository{
 		userCollection: db.Collection("users"),
 	}

--- a/infrastructure/mongo/repository/user_test.go
+++ b/infrastructure/mongo/repository/user_test.go
@@ -5,38 +5,15 @@ import (
 	"testing"
 
 	"chikokulympic-api/domain/entity"
-	mongoDB "chikokulympic-api/infrastructure/mongo"
 	"chikokulympic-api/infrastructure/mongo/repository"
+	"chikokulympic-api/infrastructure/mongo/repository/testUtils"
 
 	"github.com/stretchr/testify/assert"
 	"go.mongodb.org/mongo-driver/bson"
-	"go.mongodb.org/mongo-driver/mongo"
 )
 
-func setupTestDB(t *testing.T) (*mongo.Database, func()) {
-
-	db, client, err := mongoDB.GetMongoDBConnectionWithEnvFile(".env.local")
-	if err != nil {
-		t.Fatalf("Failed to connect to MongoDB: %v", err)
-	}
-
-	cleanup := func() {
-		err := db.Drop(context.Background())
-		if err != nil {
-			t.Logf("Warning: Failed to drop test database: %v", err)
-		}
-
-		err = mongoDB.DisconnectMongoDB(client)
-		if err != nil {
-			t.Logf("Warning: Failed to disconnect from MongoDB: %v", err)
-		}
-	}
-
-	return db, cleanup
-}
-
 func TestFindUserByUserID(t *testing.T) {
-	db, cleanup := setupTestDB(t)
+	db, cleanup := testUtils.SetupTestDB(t)
 	defer cleanup()
 
 	testUser := &entity.User{
@@ -61,7 +38,7 @@ func TestFindUserByUserID(t *testing.T) {
 }
 
 func TestFindUserByAuthID(t *testing.T) {
-	db, cleanup := setupTestDB(t)
+	db, cleanup := testUtils.SetupTestDB(t)
 	defer cleanup()
 
 	testUser := &entity.User{
@@ -86,7 +63,7 @@ func TestFindUserByAuthID(t *testing.T) {
 }
 
 func TestCreateUser(t *testing.T) {
-	db, cleanup := setupTestDB(t)
+	db, cleanup := testUtils.SetupTestDB(t)
 	defer cleanup()
 
 	repo := repository.NewUserRepository(db)
@@ -112,7 +89,7 @@ func TestCreateUser(t *testing.T) {
 }
 
 func TestUpdateUser(t *testing.T) {
-	db, cleanup := setupTestDB(t)
+	db, cleanup := testUtils.SetupTestDB(t)
 	defer cleanup()
 
 	testUser := &entity.User{
@@ -142,7 +119,7 @@ func TestUpdateUser(t *testing.T) {
 }
 
 func TestDeleteUser(t *testing.T) {
-	db, cleanup := setupTestDB(t)
+	db, cleanup := testUtils.SetupTestDB(t)
 	defer cleanup()
 
 	testUser := &entity.User{
@@ -172,7 +149,7 @@ func TestDeleteUser(t *testing.T) {
 }
 
 func TestFindUserNotFound(t *testing.T) {
-	db, cleanup := setupTestDB(t)
+	db, cleanup := testUtils.SetupTestDB(t)
 	defer cleanup()
 
 	repo := repository.NewUserRepository(db)


### PR DESCRIPTION
# 概要

- この PR をマージするとできるようになること
- 仕様や参照すべきリンクがあれば貼る

## 方針

GroupNameの重複を許さない

## 実装 (任意)
以下のinfrastructureを実装
```
type GroupRepository interface {
	FindGroupByGroupName(Group *entity.GroupName) (*entity.Group, error)
	FindGroupByUserID(UserID entity.UserID) (*entity.Group, error)
	CreateGroup(Group *entity.Group) (*entity.Group, error)
	DeleteGroup(Group *entity.Group) (*entity.Group, error)
	UpdateGroup(Group *entity.Group) (*entity.Group, error)
}
```

## テスト

- go test -v ./infrastructure/mongo/repository -run "TestCreateGroupDuplicate"
- pass

## 相談・気持ち (任意)


## WIP

- [ ] wip が外れる条件