### PR TITLE
group manegerを退出不可能にする & 並列処理でメンバー探索

### DIFF
--- a/usecase/leaveGroup.go
+++ b/usecase/leaveGroup.go
@@ -33,11 +33,21 @@ func (uc *LeaveGroupUseCaseImpl) Execute() error {
 		return fmt.Errorf("グループが見つかりません")
 	}
 
+	if groupFound.GroupManagerID == uc.userID {
+		return fmt.Errorf("グループのマネージャーは退出できません")
+	}
+
+	memberFound := false
 	for i, memberID := range groupFound.GroupMembers {
 		if memberID == uc.userID {
 			groupFound.GroupMembers = append(groupFound.GroupMembers[:i], groupFound.GroupMembers[i+1:]...)
+			memberFound = true
 			break
 		}
+	}
+
+	if !memberFound {
+		return fmt.Errorf("指定されたユーザーはグループのメンバーではありません")
 	}
 
 	_, err = uc.groupRepo.UpdateGroup(groupFound)

--- a/usecase/leaveGroup.go
+++ b/usecase/leaveGroup.go
@@ -4,6 +4,7 @@ import (
 	"chikokulympic-api/domain/entity"
 	"chikokulympic-api/domain/repository"
 	"fmt"
+	"sync"
 )
 
 type LeaveGroupUseCase interface {
@@ -30,24 +31,67 @@ func (uc *LeaveGroupUseCaseImpl) Execute() error {
 		return err
 	}
 	if groupFound == nil {
-		return fmt.Errorf("グループが見つかりません")
+		return fmt.Errorf("not found group")
 	}
 
 	if groupFound.GroupManagerID == uc.userID {
-		return fmt.Errorf("グループのマネージャーは退出できません")
+		return fmt.Errorf("can not leave group, you are the manager")
 	}
 
 	memberFound := false
-	for i, memberID := range groupFound.GroupMembers {
-		if memberID == uc.userID {
-			groupFound.GroupMembers = append(groupFound.GroupMembers[:i], groupFound.GroupMembers[i+1:]...)
-			memberFound = true
-			break
-		}
+	var mutex sync.Mutex
+	var wg sync.WaitGroup
+
+	type Result struct {
+		Index int
+		Found bool
+	}
+	resultCh := make(chan Result, 1)
+
+	numGoroutines := 4
+	if len(groupFound.GroupMembers) < numGoroutines {
+		numGoroutines = len(groupFound.GroupMembers)
+	}
+
+	chunkSize := (len(groupFound.GroupMembers) + numGoroutines - 1) / numGoroutines
+
+	for g := 0; g < numGoroutines; g++ {
+		wg.Add(1)
+		go func(startIdx int) {
+			defer wg.Done()
+
+			endIdx := startIdx + chunkSize
+			if endIdx > len(groupFound.GroupMembers) {
+				endIdx = len(groupFound.GroupMembers)
+			}
+
+			for i := startIdx; i < endIdx; i++ {
+				if groupFound.GroupMembers[i] == uc.userID {
+					select {
+					case resultCh <- Result{Index: i, Found: true}:
+					default:
+					}
+					return
+				}
+			}
+		}(g * chunkSize)
+	}
+
+	go func() {
+		wg.Wait()
+		close(resultCh)
+	}()
+
+	result, ok := <-resultCh
+	if ok && result.Found {
+		memberFound = true
+		mutex.Lock()
+		groupFound.GroupMembers = append(groupFound.GroupMembers[:result.Index], groupFound.GroupMembers[result.Index+1:]...)
+		mutex.Unlock()
 	}
 
 	if !memberFound {
-		return fmt.Errorf("指定されたユーザーはグループのメンバーではありません")
+		return fmt.Errorf("user is not a member of the group")
 	}
 
 	_, err = uc.groupRepo.UpdateGroup(groupFound)


### PR DESCRIPTION
# 概要

- この PR をマージするとできるようになること
- 仕様や参照すべきリンクがあれば貼る

## 方針

- この PR に関して考えたこと
- 結果、除外したもの

ex)
「似たような機能・画面があったので同様にした」
「データ量的にパフォーマンスはこれで十分と判断した」

## 実装 (任意)

- 方針に沿って実装していく中でレビュアーに伝えるべきものがあれば
- コードだけだと実装意図が読み解きづらい場合の図や擬似コード
- インラインでコメントしてもOK

## テスト

- マージボタンを押してもらうための安心できる材料

ex)
「ステージングでこれこれの確認をした」
「インフラからこの SQL で問題無いとお墨付きをもらった」

## 相談・気持ち (任意)

- 書いてみたが自信のないところ
- こういう案も思いついたのだけど、どう思う？
- インラインでコメントしてもOK

## WIP

- [ ] wip が外れる条件