### PR TITLE
feature server/groupを実装し，エンドポイントを追加

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -35,9 +35,13 @@ func main() {
 
 	// リポジトリの初期化
 	userRepo := repository.NewUserRepository(db)
+	groupRepo := repository.NewGroupRepository(db)
 
 	// サーバーの初期化とルーティング設定
-	authServer := serverV1.NewAuthServer(userRepo)
+	authServer := serverV1.NewAuthServer(userRepo, groupRepo)
+	groupServer := serverV1.NewGroupServer(groupRepo, userRepo)
+	
+	groupServer.RegisterRoutes(e)
 	authServer.RegisterRoutes(e)
 
 	port := config.GetEnvWithDefault("PORT", "8080")

--- a/infrastructure/mongo/repository/group.go
+++ b/infrastructure/mongo/repository/group.go
@@ -16,7 +16,7 @@ type GroupRepo struct {
 	groupCollection *mongo.Collection
 }
 
-func NewGroupRepo(db *mongo.Database) repo.GroupRepository {
+func NewGroupRepository(db *mongo.Database) repo.GroupRepository {
 	return &GroupRepo{
 		groupCollection: db.Collection("groups"),
 	}

--- a/infrastructure/mongo/repository/group_test.go
+++ b/infrastructure/mongo/repository/group_test.go
@@ -16,7 +16,7 @@ func TestGroupRepository(t *testing.T) {
 	// 各テストで共通のセットアップ処理
 	db, cleanup := testUtils.SetupTestDB(t)
 	defer cleanup()
-	repo := repository.NewGroupRepo(db)
+	repo := repository.NewGroupRepository(db)
 
 	t.Run("FindGroupByGroupName", func(t *testing.T) {
 		testCases := []struct {

--- a/presentation/v1/postGroup.go
+++ b/presentation/v1/postGroup.go
@@ -40,12 +40,10 @@ func (p *PostGroup) Handler(c echo.Context) error {
 		return c.JSON(http.StatusBadRequest, middleware.NewErrorResponse(err.Error()))
 	}
 
-	// バリデーション
 	if req.GroupName == "" || req.GroupPassword == "" || req.ManagerID == "" {
 		return c.JSON(http.StatusBadRequest, middleware.NewErrorResponse("グループ名、パスワード、作成者IDは必須です"))
 	}
 
-	// 新しいグループを作成
 	groupID := uuid.New().String()
 	group := &entity.Group{
 		GroupID:          entity.GroupID(groupID),

--- a/server/v1/auth.go
+++ b/server/v1/auth.go
@@ -8,16 +8,18 @@ import (
 )
 
 type AuthServer struct {
-	signup     *presentationV1.Signup
-	signin     *presentationV1.Signin
-	updateUser *presentationV1.UpdateUser
+	signup        *presentationV1.Signup
+	signin        *presentationV1.Signin
+	updateUser    *presentationV1.UpdateUser
+	getUserGroups *presentationV1.GetUserGroups
 }
 
-func NewAuthServer(userRepo repository.UserRepository) *AuthServer {
+func NewAuthServer(userRepo repository.UserRepository, groupRepo repository.GroupRepository) *AuthServer {
 	return &AuthServer{
-		signup:     presentationV1.NewSignup(userRepo),
-		signin:     presentationV1.NewSignin(userRepo),
-		updateUser: presentationV1.NewUpdateUser(userRepo),
+		signup:        presentationV1.NewSignup(userRepo),
+		signin:        presentationV1.NewSignin(userRepo),
+		updateUser:    presentationV1.NewUpdateUser(userRepo),
+		getUserGroups: presentationV1.NewGetUserGroups(groupRepo),
 	}
 }
 
@@ -29,4 +31,6 @@ func (s *AuthServer) RegisterRoutes(e *echo.Echo) {
 	authGroup.POST("/signin", s.signin.Handler)
 
 	authGroup.PUT("", s.updateUser.Handler)
+
+	authGroup.GET("/:user_id/groups", s.getUserGroups.Handler)
 }

--- a/server/v1/auth.go
+++ b/server/v1/auth.go
@@ -22,7 +22,7 @@ func NewAuthServer(userRepo repository.UserRepository) *AuthServer {
 }
 
 func (s *AuthServer) RegisterRoutes(e *echo.Echo) {
-	authGroup := e.Group("/auth")
+	authGroup := e.Group("/users")
 
 	authGroup.POST("/signup", s.signup.Handler)
 

--- a/server/v1/auth.go
+++ b/server/v1/auth.go
@@ -24,12 +24,9 @@ func NewAuthServer(userRepo repository.UserRepository) *AuthServer {
 func (s *AuthServer) RegisterRoutes(e *echo.Echo) {
 	authGroup := e.Group("/auth")
 
-	// サインアップ用エンドポイント
 	authGroup.POST("/signup", s.signup.Handler)
 
-	// サインイン用エンドポイント
 	authGroup.POST("/signin", s.signin.Handler)
 
-	// ユーザー情報更新用エンドポイント
 	authGroup.PUT("", s.updateUser.Handler)
 }

--- a/server/v1/group.go
+++ b/server/v1/group.go
@@ -1,0 +1,32 @@
+package v1
+
+import (
+	presentationV1 "chikokulympic-api/presentation/v1"
+	"chikokulympic-api/domain/repository"
+	"github.com/labstack/echo/v4"
+)
+
+type GroupServer struct {
+	joinGroup     *presentationV1.JoinGroup
+	leaveGroup    *presentationV1.LeaveGroup
+	getUserGroups *presentationV1.GetUserGroups
+	getGroupInfo  *presentationV1.GetGroupInfo
+}
+
+func NewGroupServer(groupRepo repository.GroupRepository, userRepo repository.UserRepository) *GroupServer {
+	return &GroupServer{
+		joinGroup:     presentationV1.NewJoinGroup(userRepo, groupRepo),
+		leaveGroup:    presentationV1.NewLeaveGroup(groupRepo),
+		getUserGroups: presentationV1.NewGetUserGroups(groupRepo),
+		getGroupInfo:  presentationV1.NewGetGroupInfo(groupRepo, userRepo),
+	}
+}
+func (s *GroupServer) RegisterRoutes(e *echo.Echo) {
+	e.POST("/group/join", s.joinGroup.Handler)
+
+	e.POST("/group/leave", s.leaveGroup.Handler)
+
+	e.GET("/user/:user_id/groups", s.getUserGroups.Handler)
+
+	e.GET("/group/:group_id", s.getGroupInfo.Handler)
+}

--- a/server/v1/group.go
+++ b/server/v1/group.go
@@ -30,6 +30,5 @@ func (s *GroupServer) RegisterRoutes(e *echo.Echo) {
 
 	groupGroup.POST("/:group_id/leave", s.leaveGroup.Handler)
 
-
 	groupGroup.GET("/:group_id", s.getGroupInfo.Handler)
 }

--- a/server/v1/group.go
+++ b/server/v1/group.go
@@ -22,11 +22,12 @@ func NewGroupServer(groupRepo repository.GroupRepository, userRepo repository.Us
 	}
 }
 func (s *GroupServer) RegisterRoutes(e *echo.Echo) {
-	e.POST("/group/join", s.joinGroup.Handler)
+	groupGroup := e.Group("/auth")
+	groupGroup.POST("/group/join", s.joinGroup.Handler)
 
-	e.POST("/group/leave", s.leaveGroup.Handler)
+	groupGroup.POST("/group/leave", s.leaveGroup.Handler)
 
-	e.GET("/user/:user_id/groups", s.getUserGroups.Handler)
+	groupGroup.GET("/user/:user_id/groups", s.getUserGroups.Handler)
 
-	e.GET("/group/:group_id", s.getGroupInfo.Handler)
+	groupGroup.GET("/group/:group_id", s.getGroupInfo.Handler)
 }

--- a/server/v1/group.go
+++ b/server/v1/group.go
@@ -7,6 +7,7 @@ import (
 )
 
 type GroupServer struct {
+	createGroup   *presentationV1.PostGroup
 	joinGroup     *presentationV1.JoinGroup
 	leaveGroup    *presentationV1.LeaveGroup
 	getUserGroups *presentationV1.GetUserGroups
@@ -15,6 +16,7 @@ type GroupServer struct {
 
 func NewGroupServer(groupRepo repository.GroupRepository, userRepo repository.UserRepository) *GroupServer {
 	return &GroupServer{
+		createGroup:  presentationV1.NewPostGroup(groupRepo, userRepo),
 		joinGroup:     presentationV1.NewJoinGroup(userRepo, groupRepo),
 		leaveGroup:    presentationV1.NewLeaveGroup(groupRepo),
 		getUserGroups: presentationV1.NewGetUserGroups(groupRepo),
@@ -22,12 +24,15 @@ func NewGroupServer(groupRepo repository.GroupRepository, userRepo repository.Us
 	}
 }
 func (s *GroupServer) RegisterRoutes(e *echo.Echo) {
-	groupGroup := e.Group("/auth")
-	groupGroup.POST("/group/join", s.joinGroup.Handler)
+	groupGroup := e.Group("/groups")
 
-	groupGroup.POST("/group/leave", s.leaveGroup.Handler)
+	groupGroup.POST("", s.createGroup.Handler)
 
-	groupGroup.GET("/user/:user_id/groups", s.getUserGroups.Handler)
+	groupGroup.POST("/join", s.joinGroup.Handler)
 
-	groupGroup.GET("/group/:group_id", s.getGroupInfo.Handler)
+	groupGroup.POST("/:group_id/leave", s.leaveGroup.Handler)
+
+	groupGroup.GET("/users/:user_id/groups", s.getUserGroups.Handler)
+
+	groupGroup.GET("/:group_id", s.getGroupInfo.Handler)
 }

--- a/server/v1/group.go
+++ b/server/v1/group.go
@@ -10,7 +10,6 @@ type GroupServer struct {
 	createGroup   *presentationV1.PostGroup
 	joinGroup     *presentationV1.JoinGroup
 	leaveGroup    *presentationV1.LeaveGroup
-	getUserGroups *presentationV1.GetUserGroups
 	getGroupInfo  *presentationV1.GetGroupInfo
 }
 
@@ -19,7 +18,6 @@ func NewGroupServer(groupRepo repository.GroupRepository, userRepo repository.Us
 		createGroup:  presentationV1.NewPostGroup(groupRepo, userRepo),
 		joinGroup:     presentationV1.NewJoinGroup(userRepo, groupRepo),
 		leaveGroup:    presentationV1.NewLeaveGroup(groupRepo),
-		getUserGroups: presentationV1.NewGetUserGroups(groupRepo),
 		getGroupInfo:  presentationV1.NewGetGroupInfo(groupRepo, userRepo),
 	}
 }
@@ -32,7 +30,6 @@ func (s *GroupServer) RegisterRoutes(e *echo.Echo) {
 
 	groupGroup.POST("/:group_id/leave", s.leaveGroup.Handler)
 
-	groupGroup.GET("/users/:user_id/groups", s.getUserGroups.Handler)
 
 	groupGroup.GET("/:group_id", s.getGroupInfo.Handler)
 }


### PR DESCRIPTION
# 概要

- groupでルーティングしたエンドポイントの実装
- ルーティングの変更を実装（auth -> users）

## 方針


## 実装 (任意)

- groupでルーティング
```
func (s *GroupServer) RegisterRoutes(e *echo.Echo) {
	groupGroup := e.Group("/groups")

	groupGroup.POST("", s.createGroup.Handler)

	groupGroup.POST("/join", s.joinGroup.Handler)

	groupGroup.POST("/:group_id/leave", s.leaveGroup.Handler)


	groupGroup.GET("/:group_id", s.getGroupInfo.Handler)
}
```

- auth -> usersに変更し，エンドポイントを追加
```
func (s *AuthServer) RegisterRoutes(e *echo.Echo) {
	authGroup := e.Group("/users")

	authGroup.POST("/signup", s.signup.Handler)

	authGroup.POST("/signin", s.signin.Handler)

	authGroup.PUT("", s.updateUser.Handler)

	authGroup.GET("/:user_id/groups", s.getUserGroups.Handler)
}
```

## テスト

- 実装したエンドポイントを実際に叩いて動作確認を行った
- リクエスト，レスポンスの形式が設計と異なっている部分があるため修正が必要
- グループに所属している人数の計算が間違っている（managerを重複して数えている）為，修正の必要あり

## 相談・気持ち (任意)

## WIP